### PR TITLE
Patch a typo is 'brew' not 'breq'

### DIFF
--- a/rasa-workshop-starter.ipynb
+++ b/rasa-workshop-starter.ipynb
@@ -112,7 +112,7 @@
    "outputs": [],
    "source": [
     "!apt-get -qq install -y graphviz libgraphviz-dev pkg-config;\n",
-    "!breq install graphviz"
+    "!brew install graphviz"
    ]
   },
   {


### PR DESCRIPTION
Hi! 
A simple patch for a typo 
The Mac Os tool is colled  'brew' not 'breq'

Thanks

Keep up the great work!